### PR TITLE
appium init timeout 발생시 retry logic을 대응하기 위한 queue logic 에러 수정

### DIFF
--- a/packages/master/package.json
+++ b/packages/master/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zigbang/honeyfarm-master",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "bin": {
     "honeyfarm-master": "bin/run"
   },

--- a/packages/master/src/modules/session/controller.ts
+++ b/packages/master/src/modules/session/controller.ts
@@ -35,6 +35,7 @@ export class SessionController {
 		// ex) zbee에서 version 7로 요청시 7.1.1 7.1.2 모두 선택 가능 하기 때문에 기존에 4723 port가 7.1.1 단말을 사용 중 이더라도 4724 port가 동일한 단말을 사용 하려고 할수 있음
 		// 그래서 appium:udid(android device serial) 사용해서 특정한 단말을 선택하는 코드 추가
 		udid = udid ? udid : SessionRouter.findUDID(remoteAppiumAddress)
+
 		if (udid && req && req.body) {
 			// tslint:disable-next-line: no-unsafe-any
 			req.body.desiredCapabilities = { ...req.body.desiredCapabilities,  "appium:udid": udid }
@@ -79,7 +80,8 @@ export class SessionController {
 			}, {
 				headers: {
 					...req.headers
-				}
+				},
+				timeout: 10 * 60 * 1000
 			})
 
 			SessionRouter.setNewCommandTimeOut(newCommandTimeout)
@@ -112,7 +114,8 @@ export class SessionController {
 			const response = await Axios.delete(`${remoteAppiumAddress}${req.path}`,  {
 				headers: {
 					...req.headers
-				}
+				},
+				timeout: 10 * 60 * 1000
 			})
 			console.log(`DeleteSession response: ${response}`)
 			const headers = response.headers as { [key: string]: string }

--- a/packages/master/src/util/SessionRouter.ts
+++ b/packages/master/src/util/SessionRouter.ts
@@ -122,8 +122,6 @@ class SessionRouter {
 	}
 
 	findDeviceResource(ip: string, platform: string, version: string, udid?: string): boolean {
-		console.log("findDeviceResource", SessionRouter.resources)
-
 		if (!this.checkNodeDeviceTimer) {
 			this.checkNodeDeviceTimer = setInterval(() => {
 				this.checkNodeDevice()

--- a/packages/master/src/util/queue.ts
+++ b/packages/master/src/util/queue.ts
@@ -19,23 +19,23 @@ export class Queue {
 		try {
 			const now = Date.now()
 
-		const INTERVAL = 90 * 1000
-		const expiredItems = this.queue.filter((q) => q.time >= now + INTERVAL)
-		for (const expired of expiredItems) {
-			expired.resolve(undefined)
-		}
-
-		const validItems = this.queue.filter((q) => q.time < now + INTERVAL)
-		for (const q of validItems) {
-			const ip = SessionRouter.findIp(q.platform, q.udid, q.version)
-			if (ip && !!q.resolve) {
-				q.resolve(ip)
-				delete q.resolve
-				return
+			const INTERVAL = 90 * 1000
+			const expiredItems = this.queue.filter((q) => q.time + INTERVAL <= now)
+			for (const expired of expiredItems) {
+				expired.resolve(undefined)
 			}
-		}
 
-		this.queue = validItems.filter((q) => !!q.resolve)
+			const validItems = this.queue.filter((q) => q.time + INTERVAL > now )
+			for (const q of validItems) {
+				const ip = SessionRouter.findIp(q.platform, q.udid, q.version)
+				if (ip && !!q.resolve) {
+					q.resolve(ip)
+					delete q.resolve
+					return
+				}
+			}
+
+			this.queue = validItems.filter((q) => !!q.resolve)
 		} catch (error) {
 			console.error("Queue looper", error)
 		}


### PR DESCRIPTION
test runner가  appium init timeout 등으로 종료되었지만 단말의.상태가 pending/running일 경우 honeyfarm master에서 일정 시간(newCommandTimeout)이 지나면 모든 세션을 삭제하고 단말 상태를 free로 돌림